### PR TITLE
Validate archive output filenames

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -62,7 +62,8 @@ Optional top-level sections:
 
 Supported placeholder locations:
 
-- `archive.name`
+- `archive.name` (`{date}` only; `{tmpdir}` is not valid here because archive
+  names must render to a single filename)
 - Filesystem source `path`
 - Command source `workdir`
 - Command source `commands`
@@ -173,7 +174,8 @@ archive:
 
 Fields:
 
-- `name`: required archive filename template.
+- `name`: required archive filename template. It must render to a single
+  filename, not a path, so `/`, `\`, `.`, and `..` are rejected.
 - `format`: required archive container format.
 - `compression`: optional compression algorithm. Defaults to `none`.
 

--- a/internal/retentra/config.go
+++ b/internal/retentra/config.go
@@ -119,6 +119,8 @@ func (cfg Config) Validate() error {
 
 	if cfg.Archive.Name == "" {
 		errs = append(errs, errors.New("archive.name is required"))
+	} else if err := validateArchiveName(cfg.Archive.Name); err != nil {
+		errs = append(errs, fmt.Errorf("archive.name: %w", err))
 	}
 	switch cfg.Archive.Format {
 	case "tar":
@@ -189,6 +191,13 @@ func validateSource(i int, source SourceConfig) []error {
 		errs = append(errs, fmt.Errorf("%s.type %q is unsupported", prefix, source.Type))
 	}
 	return errs
+}
+
+func validateArchiveName(name string) error {
+	if name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return fmt.Errorf("%q must be a filename without path separators", name)
+	}
+	return nil
 }
 
 func validateArchiveTarget(target string) error {

--- a/internal/retentra/config_test.go
+++ b/internal/retentra/config_test.go
@@ -30,6 +30,19 @@ func TestConfigValidateRejectsUnsupportedArchive(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsArchiveNamePath(t *testing.T) {
+	for _, name := range []string{"../backup.tar.gz", "nested/backup.tar.gz", `nested\backup.tar.gz`, ".", ".."} {
+		t.Run(name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Archive.Name = name
+
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("Validate() error = nil, want unsafe archive name error")
+			}
+		})
+	}
+}
+
 func TestConfigValidateRejectsAmbiguousSFTPAuth(t *testing.T) {
 	cfg := validConfig()
 	cfg.Outputs = []OutputConfig{{Type: "sftp", Label: "Upload (example.com)", Host: "example.com", Username: "backup", RemotePath: "/backups"}}

--- a/internal/retentra/run.go
+++ b/internal/retentra/run.go
@@ -47,6 +47,9 @@ func Run(ctx context.Context, configPath string, out io.Writer) error {
 
 	p := placeholders{tmpdir: tmpdir, now: time.Now()}
 	archiveName := p.expand(cfg.Archive.Name)
+	if err := validateArchiveName(archiveName); err != nil {
+		return fmt.Errorf("archive.name: %w", err)
+	}
 	archivePath := filepath.Join(tmpdir, archiveName)
 	status := Status{ReportTitle: cfg.Report.Title, ArchiveName: archiveName, ArchivePath: archivePath}
 

--- a/internal/retentra/run_test.go
+++ b/internal/retentra/run_test.go
@@ -1,0 +1,43 @@
+package retentra
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsExpandedArchiveNamePath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	config := `
+report:
+  title: Backup Report
+sources:
+  - type: filesystem
+    label: Site files
+    path: /does/not/matter
+    target: data
+archive:
+  name: "{tmpdir}.tar"
+  format: tar
+  compression: none
+outputs:
+  - type: filesystem
+    label: Local copy
+    path: /does/not/matter
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Run(context.Background(), configPath, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("Run() error = nil, want unsafe expanded archive name error")
+	}
+	if !strings.Contains(err.Error(), "archive.name") {
+		t.Fatalf("Run() error = %v, want archive.name error", err)
+	}
+}


### PR DESCRIPTION
## Summary
- reject archive names that are paths or special directory entries
- re-check archive names after placeholder expansion before building output paths
- document that archive.name must render to a single filename

## Tests
- go test ./...

Closes #1