### PR TITLE
Reject symlinks in archive sources

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -109,6 +109,9 @@ If `path` is a directory, the directory and its contents are written under
 `target`. For example, `/srv/app/data/users.json` with `target: app/data` becomes
 `app/data/users.json` in the archive.
 
+Symlinks are rejected instead of followed or preserved. This prevents a backup
+source from accidentally including files outside the configured source path.
+
 `target` must be a relative archive path. It cannot be empty, absolute, `.`, or
 contain `..` path segments.
 

--- a/internal/retentra/archive.go
+++ b/internal/retentra/archive.go
@@ -101,9 +101,12 @@ func writeZipItems(writer *zip.Writer, compression string, items []archiveItem) 
 
 func walkArchiveItem(item archiveItem, visit func(path, target string, info os.FileInfo) error) error {
 	target := cleanArchiveTarget(item.Target)
-	info, err := os.Stat(item.Path)
+	info, err := os.Lstat(item.Path)
 	if err != nil {
 		return err
+	}
+	if isSymlink(info) {
+		return fmt.Errorf("%s: symlinks are not supported", item.Path)
 	}
 	if !info.IsDir() {
 		return visit(item.Path, target, info)
@@ -112,6 +115,9 @@ func walkArchiveItem(item archiveItem, visit func(path, target string, info os.F
 	return filepath.Walk(item.Path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		if isSymlink(info) {
+			return fmt.Errorf("%s: symlinks are not supported", path)
 		}
 		rel, err := filepath.Rel(item.Path, path)
 		if err != nil {
@@ -123,6 +129,10 @@ func walkArchiveItem(item archiveItem, visit func(path, target string, info os.F
 		}
 		return visit(path, entryTarget, info)
 	})
+}
+
+func isSymlink(info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
 }
 
 func cleanArchiveTarget(target string) string {

--- a/internal/retentra/archive_test.go
+++ b/internal/retentra/archive_test.go
@@ -4,9 +4,11 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -76,5 +78,92 @@ func TestCreateZipArchiveWithTargets(t *testing.T) {
 	defer zr.Close()
 	if len(zr.File) != 1 || zr.File[0].Name != "app/db.sqlite" {
 		t.Fatalf("zip entries = %#v, want app/db.sqlite", zr.File)
+	}
+}
+
+func TestCreateArchiveRejectsSymlinkedFile(t *testing.T) {
+	for _, archive := range []ArchiveConfig{
+		{Format: "tar", Compression: "gzip"},
+		{Format: "zip", Compression: "none"},
+	} {
+		t.Run(archive.Format, func(t *testing.T) {
+			dir := t.TempDir()
+			sourceDir := filepath.Join(dir, "source")
+			if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(dir, "secret.txt")
+			if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, filepath.Join(sourceDir, "linked-secret.txt")); err != nil {
+				if errors.Is(err, os.ErrPermission) {
+					t.Skipf("symlink not permitted: %v", err)
+				}
+				t.Fatal(err)
+			}
+
+			err := createArchive(filepath.Join(dir, "backup.out"), archive, []archiveItem{{Path: sourceDir, Target: "data"}})
+			if err == nil || !strings.Contains(err.Error(), "symlinks are not supported") {
+				t.Fatalf("createArchive() error = %v, want symlink error", err)
+			}
+		})
+	}
+}
+
+func TestCreateArchiveRejectsSymlinkedDirectory(t *testing.T) {
+	for _, archive := range []ArchiveConfig{
+		{Format: "tar", Compression: "gzip"},
+		{Format: "zip", Compression: "none"},
+	} {
+		t.Run(archive.Format, func(t *testing.T) {
+			dir := t.TempDir()
+			sourceDir := filepath.Join(dir, "source")
+			if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			targetDir := filepath.Join(dir, "external")
+			if err := os.MkdirAll(targetDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(targetDir, filepath.Join(sourceDir, "linked-dir")); err != nil {
+				if errors.Is(err, os.ErrPermission) {
+					t.Skipf("symlink not permitted: %v", err)
+				}
+				t.Fatal(err)
+			}
+
+			err := createArchive(filepath.Join(dir, "backup.out"), archive, []archiveItem{{Path: sourceDir, Target: "data"}})
+			if err == nil || !strings.Contains(err.Error(), "symlinks are not supported") {
+				t.Fatalf("createArchive() error = %v, want symlink error", err)
+			}
+		})
+	}
+}
+
+func TestCreateArchiveRejectsRootSymlinkSource(t *testing.T) {
+	for _, archive := range []ArchiveConfig{
+		{Format: "tar", Compression: "gzip"},
+		{Format: "zip", Compression: "none"},
+	} {
+		t.Run(archive.Format, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "target.txt")
+			if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			source := filepath.Join(dir, "source-link")
+			if err := os.Symlink(target, source); err != nil {
+				if errors.Is(err, os.ErrPermission) {
+					t.Skipf("symlink not permitted: %v", err)
+				}
+				t.Fatal(err)
+			}
+
+			err := createArchive(filepath.Join(dir, "backup.out"), archive, []archiveItem{{Path: source, Target: "data.txt"}})
+			if err == nil || !strings.Contains(err.Error(), "symlinks are not supported") {
+				t.Fatalf("createArchive() error = %v, want symlink error", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- reject symlinked source paths before archiving
- reject symlinks encountered while walking source directories
- document the symlink policy and add tar/zip regression coverage

## Tests
- go test ./...

Closes #2