### PR TITLE
Avoid leaking command output on failures

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -151,7 +151,8 @@ If any command exits non-zero, the command source fails and later commands are
 not run.
 
 `retentra` creates `workdir` when it does not already exist. Command output is
-captured and included in the error message when a command fails.
+discarded and is not included in error messages or notifications, because backup
+commands may print secrets on failure.
 
 Command sources should write generated backup content into `{tmpdir}` or another
 dedicated output path, then list only the generated backup artifacts in

--- a/internal/retentra/source.go
+++ b/internal/retentra/source.go
@@ -3,6 +3,7 @@ package retentra
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -59,9 +60,10 @@ func runCommandSource(ctx context.Context, source SourceConfig, p placeholders) 
 		expanded := p.expand(command)
 		cmd := exec.CommandContext(ctx, "/bin/sh", "-c", expanded)
 		cmd.Dir = workdir
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("commands[%d] failed: %w: %s", i, err, string(output))
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("commands[%d] failed: %w", i, err)
 		}
 	}
 	return nil

--- a/internal/retentra/source_test.go
+++ b/internal/retentra/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -33,5 +34,26 @@ func TestCollectSourcesRunsCommandWithTmpdir(t *testing.T) {
 	}
 	if len(status.SourceResults) != 1 || status.SourceResults[0].Label != "Generated file" || !status.SourceResults[0].Success() {
 		t.Fatalf("SourceResults = %#v, want generated file success", status.SourceResults)
+	}
+}
+
+func TestCommandSourceFailureDoesNotLeakOutput(t *testing.T) {
+	tmpdir := t.TempDir()
+	source := SourceConfig{
+		Type:     "command",
+		Workdir:  "{tmpdir}",
+		Commands: []string{`printf 'SECRET_TOKEN=abc123\n' >&2; exit 1`},
+		Collect:  []CollectConfig{{Label: "Generated file", Path: "{tmpdir}/export/file.txt", Target: "generated/file.txt"}},
+	}
+
+	err := runCommandSource(context.Background(), source, placeholders{tmpdir: tmpdir, now: time.Now()})
+	if err == nil {
+		t.Fatal("runCommandSource() error = nil, want command failure")
+	}
+	if strings.Contains(err.Error(), "SECRET_TOKEN") || strings.Contains(err.Error(), "abc123") {
+		t.Fatalf("runCommandSource() error leaked command output: %v", err)
+	}
+	if !strings.Contains(err.Error(), "commands[0] failed") {
+		t.Fatalf("runCommandSource() error = %v, want command index", err)
 	}
 }


### PR DESCRIPTION
## Summary
- discard command stdout/stderr instead of attaching it to failure errors
- keep command failure errors limited to command index and exit status
- document the non-leaking command output behavior

## Tests
- go test ./...

Closes #3