### PR TITLE
Verify installer checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ curl -fsSL https://raw.githubusercontent.com/Low-Stack-Technologies/retentra/mai
 
 The installer resolves the newest published release asset through the GitHub
 Releases API and downloads the asset matching your machine:
-`retentra-linux-amd64` or `retentra-linux-arm64`. The release workflow attaches
-those assets after a release is published.
+`retentra-linux-amd64` or `retentra-linux-arm64`. It also downloads the matching
+`.sha256` asset and verifies the binary before installing it. Published releases
+must include these assets:
+
+- `retentra-linux-amd64`
+- `retentra-linux-amd64.sha256`
+- `retentra-linux-arm64`
+- `retentra-linux-arm64.sha256`
 
 The installer writes `retentra` to `$HOME/.local/bin` by default. To choose a
 different directory:

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ case "$arch" in
     exit 1
     ;;
 esac
+checksum_asset="$asset.sha256"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
@@ -47,6 +48,43 @@ fetch_url() {
   fi
 }
 
+release_asset_url() {
+  local asset_name="$1"
+  local release_json="$2"
+
+  awk -v asset="$asset_name" '
+    /"name":[[:space:]]*"/ {
+      in_asset = ($0 ~ "\"name\":[[:space:]]*\"" asset "\"")
+    }
+    in_asset && /"browser_download_url":[[:space:]]*"/ {
+      url = $0
+      sub(/^.*"browser_download_url":[[:space:]]*"/, "", url)
+      sub(/".*$/, "", url)
+      print url
+      exit
+    }
+  ' "$release_json"
+}
+
+verify_checksum() {
+  local checksum_file="$1"
+  local binary_file="$2"
+
+  if ! command -v sha256sum >/dev/null 2>&1; then
+    echo "sha256sum is required to verify retentra release integrity" >&2
+    exit 1
+  fi
+
+  local expected
+  expected="$(awk 'NF >= 1 { print $1; exit }' "$checksum_file")"
+  if [[ ! "$expected" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "Invalid SHA-256 checksum file for $asset" >&2
+    exit 1
+  fi
+
+  printf '%s  %s\n' "$expected" "$binary_file" | sha256sum -c -
+}
+
 echo "Resolving latest retentra release from $api_url"
 if ! fetch_url "$api_url" "$tmpdir/release.json"; then
   echo "GitHub latest release endpoint was unavailable; checking published releases list." >&2
@@ -64,20 +102,8 @@ EOF
   fi
 fi
 
-download_url="$(
-  awk -v asset="$asset" '
-    /"name":[[:space:]]*"/ {
-      in_asset = ($0 ~ "\"name\":[[:space:]]*\"" asset "\"")
-    }
-    in_asset && /"browser_download_url":[[:space:]]*"/ {
-      url = $0
-      sub(/^.*"browser_download_url":[[:space:]]*"/, "", url)
-      sub(/".*$/, "", url)
-      print url
-      exit
-    }
-  ' "$tmpdir/release.json"
-)"
+download_url="$(release_asset_url "$asset" "$tmpdir/release.json")"
+checksum_url="$(release_asset_url "$checksum_asset" "$tmpdir/release.json")"
 
 if [[ -z "$download_url" ]]; then
   cat >&2 <<EOF
@@ -97,8 +123,26 @@ EOF
   exit 1
 fi
 
+if [[ -z "$checksum_url" ]]; then
+  cat >&2 <<EOF
+Failed to find release checksum asset.
+
+Expected checksum asset name:
+  $checksum_asset
+
+Latest release API endpoint:
+  $api_url
+
+Releases list API endpoint:
+  $releases_api_url
+
+Every published release asset must include a matching .sha256 file.
+EOF
+  exit 1
+fi
+
 echo "Downloading retentra from $download_url"
-if ! fetch_url "$download_url" "$tmpdir/retentra"; then
+if ! fetch_url "$download_url" "$tmpdir/$asset"; then
   cat >&2 <<EOF
 Failed to download retentra.
 
@@ -111,8 +155,25 @@ EOF
   exit 1
 fi
 
-chmod +x "$tmpdir/retentra"
-mv "$tmpdir/retentra" "$binary_path"
+echo "Downloading checksum from $checksum_url"
+if ! fetch_url "$checksum_url" "$tmpdir/$checksum_asset"; then
+  cat >&2 <<EOF
+Failed to download retentra checksum.
+
+Resolved checksum asset:
+  $checksum_url
+
+Latest release API endpoint:
+  $api_url
+EOF
+  exit 1
+fi
+
+echo "Verifying SHA-256 checksum"
+verify_checksum "$tmpdir/$checksum_asset" "$tmpdir/$asset"
+
+chmod +x "$tmpdir/$asset"
+mv "$tmpdir/$asset" "$binary_path"
 
 echo "Installed retentra to $binary_path"
 if ! command -v retentra >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- require a matching .sha256 asset for each release binary
- verify downloaded binaries with sha256sum before installing
- document the expected release assets in README

## Tests
- bash -n install.sh
- go test ./...

Closes #4