### PR TITLE
Attempt all outputs before failing

### DIFF
--- a/internal/retentra/run.go
+++ b/internal/retentra/run.go
@@ -91,14 +91,16 @@ func runBackup(ctx context.Context, cfg Config, p placeholders, archivePath, arc
 	status.ArchiveCreated = true
 
 	fmt.Fprintln(out, "Delivering outputs")
+	var outputErrs []error
 	for i, output := range cfg.Outputs {
 		if _, err := deliverOutput(output, archivePath, archiveName); err != nil {
 			status.OutputResults = append(status.OutputResults, ReportResult{Label: output.Label, Error: err})
-			return fmt.Errorf("outputs[%d]: %w", i, err)
+			outputErrs = append(outputErrs, fmt.Errorf("outputs[%d]: %w", i, err))
+			continue
 		}
 		status.OutputResults = append(status.OutputResults, ReportResult{Label: output.Label})
 	}
-	return nil
+	return joinErrors(outputErrs)
 }
 
 func joinErrors(errs []error) error {

--- a/internal/retentra/run_test.go
+++ b/internal/retentra/run_test.go
@@ -41,3 +41,44 @@ outputs:
 		t.Fatalf("Run() error = %v, want archive.name error", err)
 	}
 }
+
+func TestRunBackupAttemptsLaterOutputsAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.txt")
+	if err := os.WriteFile(source, []byte("backup data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	blocker := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("blocker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	successOutput := filepath.Join(dir, "successful-output")
+	cfg := Config{
+		Report:  ReportConfig{Title: "Backup Report"},
+		Sources: []SourceConfig{{Type: "filesystem", Label: "Source", Path: source, Target: "source.txt"}},
+		Archive: ArchiveConfig{Name: "backup.tar", Format: "tar", Compression: "none"},
+		Outputs: []OutputConfig{
+			{Type: "filesystem", Label: "Broken output", Path: filepath.Join(blocker, "child")},
+			{Type: "filesystem", Label: "Successful output", Path: successOutput},
+		},
+	}
+	status := Status{}
+	archivePath := filepath.Join(dir, "backup.tar")
+
+	err := runBackup(context.Background(), cfg, placeholders{}, archivePath, "backup.tar", &bytes.Buffer{}, &status)
+	if err == nil {
+		t.Fatal("runBackup() error = nil, want first output failure")
+	}
+	if len(status.OutputResults) != 2 {
+		t.Fatalf("OutputResults = %#v, want both outputs recorded", status.OutputResults)
+	}
+	if status.OutputResults[0].Success() {
+		t.Fatalf("first output result = %#v, want failure", status.OutputResults[0])
+	}
+	if !status.OutputResults[1].Success() {
+		t.Fatalf("second output result = %#v, want success", status.OutputResults[1])
+	}
+	if _, err := os.Stat(filepath.Join(successOutput, "backup.tar")); err != nil {
+		t.Fatalf("successful output was not delivered: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- continue delivery after individual output failures
- record success/failure status for every configured output
- return joined output errors after all destinations have been attempted

## Tests
- go test ./...

Closes #7