### PR TITLE
Fix Discord notification docs

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -321,7 +321,8 @@ Fields:
 - `type`: must be `discord`.
 - `webhook_url`: required Discord webhook URL.
 
-Discord notifications send a JSON body with a `content` field.
+Discord notifications send an embed-only JSON payload with status fields for
+sources, archive creation, included targets, outputs, and unattributed errors.
 
 ### NTFY Notification
 


### PR DESCRIPTION
## Summary
- document the actual embed-only Discord webhook payload
- remove the incorrect reference to a content field

## Tests
- go test ./...

Closes #9