### PR TITLE
Add config validation command

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,12 +6,17 @@
 retentra config.yaml [config2.yaml ...]
 retentra *-retentra.yaml
 retentra --no-parallel *-retentra.yaml
+retentra validate config.yaml [config2.yaml ...]
 ```
 
 Each file describes what to collect, how to archive it, where to deliver the
 archive, and which status notifications to send. Multiple configs run in
 parallel by default and independently from each other. Use `--no-parallel` to
 run configs sequentially.
+
+Use `retentra validate ...` to load and validate configuration files without
+running commands, creating archives, delivering outputs, or sending
+notifications.
 
 ## Top-Level Structure
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ retentra --help
 retentra -h
 ```
 
+Validate one or more configuration files without running backups:
+
+```sh
+retentra validate config.yaml
+retentra validate *-retentra.yaml
+```
+
 Build a local binary:
 
 ```sh

--- a/cmd/retentra/main.go
+++ b/cmd/retentra/main.go
@@ -13,12 +13,14 @@ import (
 )
 
 var runConfig = retentra.Run
+var loadConfig = retentra.LoadConfig
 
 func main() {
 	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr))
 }
 
 type cliOptions struct {
+	validate    bool
 	parallel    bool
 	configPaths []string
 }
@@ -35,6 +37,13 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	if opts.validate {
+		if !validateConfigs(opts.configPaths, stdout, stderr) {
+			return 1
+		}
+		return 0
+	}
+
 	if !runConfigs(opts, stdout, stderr) {
 		return 1
 	}
@@ -42,6 +51,10 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 }
 
 func parseCLI(args []string) (cliOptions, bool, error) {
+	if len(args) > 0 && args[0] == "validate" {
+		return parseValidateCLI(args[1:])
+	}
+
 	var noParallel bool
 	var help bool
 	var configArgs []string
@@ -69,6 +82,33 @@ func parseCLI(args []string) (cliOptions, bool, error) {
 		return cliOptions{}, false, fmt.Errorf("usage: retentra [--no-parallel] config.yaml [config2.yaml ...]")
 	}
 	return cliOptions{parallel: !noParallel, configPaths: configPaths}, false, nil
+}
+
+func parseValidateCLI(args []string) (cliOptions, bool, error) {
+	var help bool
+	var configArgs []string
+	for _, arg := range args {
+		switch arg {
+		case "--help", "-h":
+			help = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return cliOptions{}, false, fmt.Errorf("unknown flag %q", arg)
+			}
+			configArgs = append(configArgs, arg)
+		}
+	}
+	if help {
+		return cliOptions{}, true, nil
+	}
+	configPaths, err := expandConfigArgs(configArgs)
+	if err != nil {
+		return cliOptions{}, false, err
+	}
+	if len(configPaths) == 0 {
+		return cliOptions{}, false, fmt.Errorf("usage: retentra validate config.yaml [config2.yaml ...]")
+	}
+	return cliOptions{validate: true, configPaths: configPaths}, false, nil
 }
 
 func expandConfigArgs(args []string) ([]string, error) {
@@ -104,6 +144,20 @@ func expandConfigArgs(args []string) ([]string, error) {
 
 func hasGlobMeta(path string) bool {
 	return strings.ContainsAny(path, "*?[")
+}
+
+func validateConfigs(configPaths []string, stdout, stderr io.Writer) bool {
+	var mu sync.Mutex
+	ok := true
+	for _, configPath := range configPaths {
+		if _, err := loadConfig(configPath); err != nil {
+			writeRunError(stderr, &mu, configPath, err)
+			ok = false
+			continue
+		}
+		fmt.Fprintln(newPrefixWriter(stdout, configPath, &mu), "Config is valid")
+	}
+	return ok
 }
 
 func runConfigs(opts cliOptions, stdout, stderr io.Writer) bool {
@@ -189,6 +243,7 @@ func printHelp(out io.Writer) {
 
 Usage:
   retentra [--no-parallel] config.yaml [config2.yaml ...]
+  retentra validate config.yaml [config2.yaml ...]
 
 Arguments:
   config.yaml    Path or glob pattern for a retentra YAML configuration file.
@@ -203,5 +258,6 @@ Examples:
   retentra *-retentra.yaml
   retentra --no-parallel *-retentra.yaml
   retentra /etc/retentra/nightly.yaml
+  retentra validate /etc/retentra/nightly.yaml
 `)
 }

--- a/cmd/retentra/main_test.go
+++ b/cmd/retentra/main_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"retentra/internal/retentra"
 )
 
 func TestRunCLIHelpLong(t *testing.T) {
@@ -154,6 +156,67 @@ func TestRunCLIRejectsDuplicateConfigPath(t *testing.T) {
 	}
 }
 
+func TestRunCLIValidateLoadsConfigsWithoutRunningBackups(t *testing.T) {
+	restoreRun := stubRunConfig(t, func(_ context.Context, _ string, _ io.Writer) error {
+		t.Fatal("runConfig should not be called by validate")
+		return nil
+	})
+	defer restoreRun()
+	restoreLoad := stubLoadConfig(t, func(configPath string) (retentra.Config, error) {
+		if configPath != "config.yaml" {
+			t.Fatalf("configPath = %q, want config.yaml", configPath)
+		}
+		return retentra.Config{}, nil
+	})
+	defer restoreLoad()
+	var stdout, stderr bytes.Buffer
+
+	code := runCLI([]string{"validate", "config.yaml"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "[config.yaml] Config is valid") {
+		t.Fatalf("stdout = %q, want validation success", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunCLIValidateReportsConfigErrors(t *testing.T) {
+	restoreLoad := stubLoadConfig(t, func(_ string) (retentra.Config, error) {
+		return retentra.Config{}, errors.New("invalid config")
+	})
+	defer restoreLoad()
+	var stdout, stderr bytes.Buffer
+
+	code := runCLI([]string{"validate", "bad.yaml"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "[bad.yaml] retentra: invalid config") {
+		t.Fatalf("stderr = %q, want validation error", stderr.String())
+	}
+}
+
+func TestRunCLIValidateRequiresConfig(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	code := runCLI([]string{"validate"}, &stdout, &stderr)
+
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: retentra validate config.yaml [config2.yaml ...]") {
+		t.Fatalf("stderr = %q, want validate usage", stderr.String())
+	}
+}
+
 func TestRunCLINoParallelRunsInOrder(t *testing.T) {
 	var mu sync.Mutex
 	var order []string
@@ -266,6 +329,15 @@ func stubRunConfig(t *testing.T, fn func(context.Context, string, io.Writer) err
 	runConfig = fn
 	return func() {
 		runConfig = previous
+	}
+}
+
+func stubLoadConfig(t *testing.T, fn func(string) (retentra.Config, error)) func() {
+	t.Helper()
+	previous := loadConfig
+	loadConfig = fn
+	return func() {
+		loadConfig = previous
 	}
 }
 


### PR DESCRIPTION
## Summary
- add retentra validate for config-only validation
- support multiple config paths and globs in validation mode
- document validation usage and test success/failure paths

## Tests
- go test ./...

Closes #10