### PR TITLE
Add output retention policy

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -34,6 +34,8 @@ outputs:
   - type: filesystem
     label: Local copy
     path: /var/backups
+    retention:
+      keep_last: 7
 
 notifications:
   - type: ntfy
@@ -226,6 +228,8 @@ Fields:
 - `type`: must be `filesystem`.
 - `label`: required display label for stdout and notification reports.
 - `path`: required local directory where the archive should be copied.
+- `retention.keep_last`: optional number of matching archives to keep. Defaults
+  to `0`, which disables pruning.
 
 The output directory is created if it does not exist. The archive filename is the
 rendered `archive.name`.
@@ -259,6 +263,8 @@ Fields:
 - `known_hosts`: optional known hosts file. Defaults to `~/.ssh/known_hosts`.
 - `insecure_ignore_host_key`: optional boolean. Set to `true` to skip host key
   verification.
+- `retention.keep_last`: optional number of matching archives to keep. Defaults
+  to `0`, which disables pruning.
 
 Exactly one of `identity_file` or `password` must be set.
 
@@ -266,6 +272,27 @@ Exactly one of `identity_file` or `password` must be set.
 
 `remote_path` is created if it does not exist. The uploaded file name is the
 rendered `archive.name`.
+
+### Output Retention
+
+Retention is opt-in per output:
+
+```yaml
+outputs:
+  - type: filesystem
+    label: Local copy
+    path: /var/backups
+    retention:
+      keep_last: 7
+```
+
+`keep_last` keeps the newest matching archives by modification time and removes
+older matches after a successful delivery to that output. A value of `0`
+disables retention and is the default. Negative values fail validation.
+
+Retention matches files by `archive.name`. The `{date}` placeholder matches
+archive dates formatted as `YYYY-MM-DD`; other filenames in the output
+directory are ignored.
 
 Prefer `known_hosts` verification for real backups. Use
 `insecure_ignore_host_key: true` only for local testing or controlled
@@ -457,6 +484,7 @@ Common validation failures:
 - `archive.compression` is unsupported for the selected format.
 - An SFTP output sets both `identity_file` and `password`, or neither.
 - An NTFY notification sets only one of `username` or `password`.
+- `retention.keep_last` is negative.
 
 Secrets such as SFTP passwords, Discord webhook URLs, and NTFY passwords should
 not be committed to public repositories.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,6 +31,8 @@ outputs:
   - type: filesystem
     label: Local copy
     path: /var/backups
+    retention:
+      keep_last: 7
 
   - type: sftp
     label: Upload (backup.example.com)

--- a/internal/retentra/config.go
+++ b/internal/retentra/config.go
@@ -45,17 +45,22 @@ type ArchiveConfig struct {
 }
 
 type OutputConfig struct {
-	Type         string `yaml:"type"`
-	Label        string `yaml:"label"`
-	Path         string `yaml:"path"`
-	Host         string `yaml:"host"`
-	Port         int    `yaml:"port"`
-	Username     string `yaml:"username"`
-	RemotePath   string `yaml:"remote_path"`
-	IdentityFile string `yaml:"identity_file"`
-	Password     string `yaml:"password"`
-	KnownHosts   string `yaml:"known_hosts"`
-	Insecure     bool   `yaml:"insecure_ignore_host_key"`
+	Type         string          `yaml:"type"`
+	Label        string          `yaml:"label"`
+	Path         string          `yaml:"path"`
+	Host         string          `yaml:"host"`
+	Port         int             `yaml:"port"`
+	Username     string          `yaml:"username"`
+	RemotePath   string          `yaml:"remote_path"`
+	IdentityFile string          `yaml:"identity_file"`
+	Password     string          `yaml:"password"`
+	KnownHosts   string          `yaml:"known_hosts"`
+	Insecure     bool            `yaml:"insecure_ignore_host_key"`
+	Retention    RetentionConfig `yaml:"retention"`
+}
+
+type RetentionConfig struct {
+	KeepLast int `yaml:"keep_last"`
 }
 
 type NotificationConfig struct {
@@ -237,6 +242,9 @@ func validateOutput(i int, output OutputConfig) []error {
 		}
 	default:
 		errs = append(errs, fmt.Errorf("%s.type %q is unsupported", prefix, output.Type))
+	}
+	if output.Retention.KeepLast < 0 {
+		errs = append(errs, fmt.Errorf("%s.retention.keep_last must be greater than or equal to 0", prefix))
 	}
 	return errs
 }

--- a/internal/retentra/config_test.go
+++ b/internal/retentra/config_test.go
@@ -111,6 +111,15 @@ func TestConfigValidateRejectsMissingOutputLabel(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsNegativeRetention(t *testing.T) {
+	cfg := validConfig()
+	cfg.Outputs[0].Retention.KeepLast = -1
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want negative retention error")
+	}
+}
+
 func validConfig() Config {
 	return Config{
 		Report:  ReportConfig{Title: "Backup Report"},

--- a/internal/retentra/output.go
+++ b/internal/retentra/output.go
@@ -55,6 +55,27 @@ func copyFile(source, destination string) error {
 }
 
 func uploadSFTP(output OutputConfig, archivePath, archiveName string) error {
+	return withSFTPClient(output, func(client *sftp.Client) error {
+		if err := client.MkdirAll(output.RemotePath); err != nil {
+			return err
+		}
+		remoteFile, err := client.Create(filepath.ToSlash(filepath.Join(output.RemotePath, archiveName)))
+		if err != nil {
+			return err
+		}
+		defer remoteFile.Close()
+
+		localFile, err := os.Open(archivePath)
+		if err != nil {
+			return err
+		}
+		defer localFile.Close()
+		_, err = io.Copy(remoteFile, localFile)
+		return err
+	})
+}
+
+func withSFTPClient(output OutputConfig, use func(*sftp.Client) error) error {
 	auth, err := sftpAuth(output)
 	if err != nil {
 		return err
@@ -81,23 +102,7 @@ func uploadSFTP(output OutputConfig, archivePath, archiveName string) error {
 		return err
 	}
 	defer client.Close()
-
-	if err := client.MkdirAll(output.RemotePath); err != nil {
-		return err
-	}
-	remoteFile, err := client.Create(filepath.ToSlash(filepath.Join(output.RemotePath, archiveName)))
-	if err != nil {
-		return err
-	}
-	defer remoteFile.Close()
-
-	localFile, err := os.Open(archivePath)
-	if err != nil {
-		return err
-	}
-	defer localFile.Close()
-	_, err = io.Copy(remoteFile, localFile)
-	return err
+	return use(client)
 }
 
 func sftpAuth(output OutputConfig) (ssh.AuthMethod, error) {

--- a/internal/retentra/retention.go
+++ b/internal/retentra/retention.go
@@ -1,0 +1,106 @@
+package retentra
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pkg/sftp"
+)
+
+type retentionEntry struct {
+	name    string
+	modTime time.Time
+}
+
+func applyOutputRetention(output OutputConfig, archiveNameTemplate string) error {
+	if output.Retention.KeepLast == 0 {
+		return nil
+	}
+	matcher, err := archiveNameMatcher(archiveNameTemplate)
+	if err != nil {
+		return err
+	}
+	switch output.Type {
+	case "filesystem":
+		return pruneFilesystemOutput(output.Path, matcher, output.Retention.KeepLast)
+	case "sftp":
+		return pruneSFTPOutput(output, matcher, output.Retention.KeepLast)
+	default:
+		return fmt.Errorf("output type %q is unsupported", output.Type)
+	}
+}
+
+func archiveNameMatcher(template string) (*regexp.Regexp, error) {
+	pattern := regexp.QuoteMeta(template)
+	pattern = strings.ReplaceAll(pattern, regexp.QuoteMeta("{date}"), `\d{4}-\d{2}-\d{2}`)
+	return regexp.Compile("^" + pattern + "$")
+}
+
+func pruneFilesystemOutput(dir string, matcher *regexp.Regexp, keepLast int) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var matches []retentionEntry
+	for _, entry := range entries {
+		if entry.IsDir() || !matcher.MatchString(entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		matches = append(matches, retentionEntry{name: entry.Name(), modTime: info.ModTime()})
+	}
+	sortRetentionEntries(matches)
+	for _, entry := range matches[retentionDeleteStart(len(matches), keepLast):] {
+		if err := os.Remove(filepath.Join(dir, entry.name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func pruneSFTPOutput(output OutputConfig, matcher *regexp.Regexp, keepLast int) error {
+	return withSFTPClient(output, func(client *sftp.Client) error {
+		entries, err := client.ReadDir(output.RemotePath)
+		if err != nil {
+			return err
+		}
+		var matches []retentionEntry
+		for _, entry := range entries {
+			if entry.IsDir() || !matcher.MatchString(entry.Name()) {
+				continue
+			}
+			matches = append(matches, retentionEntry{name: entry.Name(), modTime: entry.ModTime()})
+		}
+		sortRetentionEntries(matches)
+		for _, entry := range matches[retentionDeleteStart(len(matches), keepLast):] {
+			if err := client.Remove(filepath.ToSlash(filepath.Join(output.RemotePath, entry.name))); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func retentionDeleteStart(total, keepLast int) int {
+	if keepLast >= total {
+		return total
+	}
+	return keepLast
+}
+
+func sortRetentionEntries(entries []retentionEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].modTime.Equal(entries[j].modTime) {
+			return entries[i].name > entries[j].name
+		}
+		return entries[i].modTime.After(entries[j].modTime)
+	})
+}

--- a/internal/retentra/retention_test.go
+++ b/internal/retentra/retention_test.go
@@ -1,0 +1,67 @@
+package retentra
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestApplyFilesystemRetentionKeepsNewestMatchingArchives(t *testing.T) {
+	dir := t.TempDir()
+	writeRetentionFile(t, dir, "backup-2026-04-17.tar.gz", time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC))
+	writeRetentionFile(t, dir, "backup-2026-04-18.tar.gz", time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	writeRetentionFile(t, dir, "backup-2026-04-19.tar.gz", time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC))
+	writeRetentionFile(t, dir, "notes.txt", time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC))
+
+	output := OutputConfig{
+		Type:      "filesystem",
+		Path:      dir,
+		Retention: RetentionConfig{KeepLast: 2},
+	}
+	if err := applyOutputRetention(output, "backup-{date}.tar.gz"); err != nil {
+		t.Fatalf("applyOutputRetention() error = %v", err)
+	}
+
+	assertRetentionFileMissing(t, dir, "backup-2026-04-17.tar.gz")
+	assertRetentionFileExists(t, dir, "backup-2026-04-18.tar.gz")
+	assertRetentionFileExists(t, dir, "backup-2026-04-19.tar.gz")
+	assertRetentionFileExists(t, dir, "notes.txt")
+}
+
+func TestApplyFilesystemRetentionDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeRetentionFile(t, dir, "backup-2026-04-17.tar.gz", time.Now())
+
+	output := OutputConfig{Type: "filesystem", Path: dir}
+	if err := applyOutputRetention(output, "backup-{date}.tar.gz"); err != nil {
+		t.Fatalf("applyOutputRetention() error = %v", err)
+	}
+
+	assertRetentionFileExists(t, dir, "backup-2026-04-17.tar.gz")
+}
+
+func writeRetentionFile(t *testing.T, dir, name string, modTime time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(name), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertRetentionFileExists(t *testing.T, dir, name string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+		t.Fatalf("%s should exist: %v", name, err)
+	}
+}
+
+func assertRetentionFileMissing(t *testing.T, dir, name string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+		t.Fatalf("%s should be removed, stat error = %v", name, err)
+	}
+}

--- a/internal/retentra/run.go
+++ b/internal/retentra/run.go
@@ -96,6 +96,10 @@ func runBackup(ctx context.Context, cfg Config, p placeholders, archivePath, arc
 			status.OutputResults = append(status.OutputResults, ReportResult{Label: output.Label, Error: err})
 			return fmt.Errorf("outputs[%d]: %w", i, err)
 		}
+		if err := applyOutputRetention(output, cfg.Archive.Name); err != nil {
+			status.OutputResults = append(status.OutputResults, ReportResult{Label: output.Label, Error: err})
+			return fmt.Errorf("outputs[%d].retention: %w", i, err)
+		}
 		status.OutputResults = append(status.OutputResults, ReportResult{Label: output.Label})
 	}
 	return nil


### PR DESCRIPTION
## Summary
- add optional per-output retention.keep_last configuration
- prune matching filesystem and SFTP archives after successful delivery
- document retention behavior and add filesystem retention coverage

## Tests
- go test ./...

Closes #11